### PR TITLE
feat: use apksigner instead of deprecated jarsigner

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,19 @@ Stigma is currently "beta" software.  Numerous bugs and limitations exist, which
 * aapt (available in Ubuntu repository ```apt install aapt``` and at [https://developer.android.com/studio/command-line/aapt2#download_aapt2](https://developer.android.com/studio/command-line/aapt2#download_aapt2))
 * networkx version 2.5.1 (we recommend installing via pip3; see below).  Available in Ubuntu repository ```apt install python3-networkx```. Networkx source code is available here: [https://github.com/networkx/networkx](https://github.com/networkx/networkx)
 * matplotlib version 3.1.2 (we recommend installing via pip3; see below).  Available in Ubuntu repository ```apt install python3-matplotlib```. Matplotlib source code is available here: [https://matplotlib.org/](https://matplotlib.org/)
+* Android Build Tools (`build-tools`) version 32.0.0 ([ref](https://developer.android.com/studio/releases/build-tools)). Android does not distribute Build Tools individually so the one have to install the Android SDK in which Build Tools are included. The Android SDK is available via the [Android Studio](https://developer.android.com/studio) SDK Manager. After installing the SDK from the SDK Manager in Android Studio, you also need to put the path including `apksigner` into your `PATH` environment variable. To do this,
+    1. Find your Android SDK root directory. On macOS, this is typically at `~/Library/Android/sdk`.
+       - On Windows, this is typically at `C:\Users\YOUR_USERNAME\AppData\Local\Android\Sdk`.
+       - On Linux, this is typically at `~/Android/Sdk`.
+       - Check Android Studio's SDK Manager settings to confirm.
+    2. Find the `build-tools` directory under your Android SDK root directory.
+       - On macOS, this is typically at `~/Library/Android/sdk/build-tools/32.0.0`.
+       - On Windows, this is typically at `C:\Users\YOUR_USERNAME\AppData\Local\Android\Sdk\build-tools\32.0.0`.
+       - On Linux, this is typically at `~/Android/Sdk/build-tools/32.0.0`.
+    3. Add the `build-tools` directory to your `PATH` environment variable.
+       - On macOS, you can add `export PATH=$PATH:~/Library/Android/sdk/build-tools/32.0.0` to your `~/.bash_profile` or your shell's equivalent configuration file.
+       - On Windows, add `C:\Users\YOUR_USERNAME\AppData\Local\Android\Sdk\build-tools\32.0.0` to your `PATH` environment variable.
+       - On Linux, add `export PATH=$PATH:~/Android/Sdk/build-tools/32.0.0` to your `~/.bashrc`, `~/.profile`, `~/.bash_profile`, or your shell's equivalent configuration file.
 
 Recommended installation method for networkx and matplotlib is to use `pip3`. Enter the following on the command line:
 ```pip3 install networkx```

--- a/README.md
+++ b/README.md
@@ -87,10 +87,11 @@ Stigma is currently "beta" software.  Numerous bugs and limitations exist, which
 * networkx version 2.5.1 (we recommend installing via pip3; see below).  Available in Ubuntu repository ```apt install python3-networkx```. Networkx source code is available here: [https://github.com/networkx/networkx](https://github.com/networkx/networkx)
 * matplotlib version 3.1.2 (we recommend installing via pip3; see below).  Available in Ubuntu repository ```apt install python3-matplotlib```. Matplotlib source code is available here: [https://matplotlib.org/](https://matplotlib.org/)
 * Android Build Tools (`build-tools`) version 32.0.0 ([ref](https://developer.android.com/studio/releases/build-tools)). Android does not distribute Build Tools individually so the one have to install the Android SDK in which Build Tools are included. The Android SDK is available via the [Android Studio](https://developer.android.com/studio) SDK Manager. After installing the SDK from the SDK Manager in Android Studio, you also need to put the path including `apksigner` into your `PATH` environment variable. To do this,
-    1. Find your Android SDK root directory. On macOS, this is typically at `~/Library/Android/sdk`.
+    1. Find your Android SDK root directory.
+       - On macOS, this is typically at `~/Library/Android/sdk`.
        - On Windows, this is typically at `C:\Users\YOUR_USERNAME\AppData\Local\Android\Sdk`.
        - On Linux, this is typically at `~/Android/Sdk`.
-       - Check Android Studio's SDK Manager settings to confirm.
+       - *Check Android Studio's SDK Manager settings to confirm.*
     2. Find the `build-tools` directory under your Android SDK root directory.
        - On macOS, this is typically at `~/Library/Android/sdk/build-tools/32.0.0`.
        - On Windows, this is typically at `C:\Users\YOUR_USERNAME\AppData\Local\Android\Sdk\build-tools\32.0.0`.

--- a/Stigma.py
+++ b/Stigma.py
@@ -399,8 +399,9 @@ def signApk():
 
     # print("Signing...")
     newAppName = getNewAPKName()
-    # jarsigner -keystore stigma-keys.keystore -storepass MzJiY2ZjNjY5Z ./leak_detect_test/Tracked_StigmaTest.apk stigma_keystore_alias
-    cmd = ["jarsigner", "-keystore", keystore_name, "-storepass", password, newAppName, stigma_alias]
+    # apksigner sign --ks stigma-keys.keystore --ks-pass pass:MzJiY2ZjNjY5Z --ks-key-alias stigma_keystore_alias ./leak_detect_test/Tracked_StigmaTest.apk
+    cmd = ["apksigner", "sign", "--ks", keystore_name, "--ks-pass", "pass:"+password, "--ks-key-alias", stigma_alias, newAppName]
+    print("Signing with apksigner:", cmd)
     if (os.name == "nt"):
         completedProcess = subprocess.run(cmd, shell=True)
     elif (os.name == "posix"):


### PR DESCRIPTION
According to https://developer.android.com/studio/command-line/apksigner it appears that apksigner is the correct way to sign the APK.

This fixes a problem in which an Android 12 simulator complains:

```
The APK failed to install.
Error: -124: Failed parse during installPackageLl: Targeting R+ (version 30 and above) requires the resources.arsc of installed APKs to be stored uncompressed and aligned on a 4-byte boundary
```

<details>
<summary>Simulator Screenshot</summary>

![image](https://user-images.githubusercontent.com/12567059/195436112-7e5e58b0-8992-4a43-bf25-6cb7261cb995.png)



</details>